### PR TITLE
Add Snowflake UDF recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Recipes built around a specific model, SDK, or agent framework.
 | Claude | [Due-Diligence Agent](./due-diligence/) | Upload a deal PDF → Unsiloed parse + Claude (LangChain) analyst + E2B sandbox that verifies every figure → risk-flagged diligence memo you can chat with |
 | OpenAI | [Agentic CLI](./openai/cli/) | LangChain ReAct agent in a terminal REPL — plain-English document processing via Unsiloed |
 | n8n | [Unsiloed node](./n8n-nodes-unsiloed/) | Community node to parse and extract documents with Unsiloed inside n8n workflows |
+| Snowflake | [SQL UDF](./snowflake/) | Python UDF that extracts documents from a Snowflake stage entirely in SQL, returning fields with confidence scores and citations |
 
 ### Portable agent skills
 

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -5,7 +5,7 @@ Extract structured data from documents in a Snowflake stage using Unsiloed, enti
 ## Prerequisites
 
 - A Snowflake role that can create a network rule, secret, external access integration, and function (`ACCOUNTADMIN` works).
-- An Unsiloed API key — [sign up at unsiloed.ai](https://www.unsiloed.ai).
+- An Unsiloed API key. [Sign up at unsiloed.ai](https://www.unsiloed.ai).
 - A stage holding your documents. For an internal stage, create it with `ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')` so `SnowflakeFile` can read it.
 
 ## Setup
@@ -36,13 +36,35 @@ Each field comes back as an object with a value, a confidence score, and a citat
 ```json
 {
   "total": {
-    "value": "$4.11",
-    "score": { "grounding_score": 0.998, "extraction_score": 0.992 },
-    "citation": { "page": 1, "bbox": [541, 142, 573, 155] }
+    "value": "4.11",
+    "score": { "grounding_score": 0.998, "extraction_score": 0.989 },
+    "citation": { "page": 1, "bbox": [548, 142, 573, 156], "page_width": 612.0, "page_height": 792.0 }
   }
 }
 ```
 
+`bbox` is `[x0, y0, x1, y1]` in points, measured against the `page_width` and `page_height` in the same object, so you can scale it to whatever you render the page at.
+
 Because Unsiloed accepts an array-of-objects schema, repeating rows (line items, holdings, table rows) need no columnar rewrite. To process a whole stage in one query, join to `DIRECTORY(@stage)`.
+
+## File types
+
+`/v2/extract` chooses its decoder from the file extension, and a scoped file URL is encrypted, so the UDF can't read the name off the URL. It identifies PDFs, PNG, JPEG and TIFF images, Office files, and HTML from the leading bytes instead. If you have a format it doesn't recognise, pass the name yourself as the third argument:
+
+```sql
+SELECT unsiloed_extract(
+    BUILD_SCOPED_FILE_URL(@MY_DB.MY_SCHEMA.DOC_STAGE, 'contract.docx'),
+    '{ "type": "object", "properties": { "counterparty": { "type": "string" } } }',
+    'contract.docx'
+) AS result;
+```
+
+Joining to `DIRECTORY(@stage)` gives you `relative_path` for exactly this.
+
+## Notes
+
+- The UDF polls for up to five minutes (`MAX_POLLS` × `POLL_SECONDS` in `setup.sql`). Long multi-page documents can need more, so raise `MAX_POLLS` if you see `{"_unsiloed_error": "timeout"}`.
+- The first call after creating the external access integration sometimes times out while the Python environment cold-starts. Run it again.
+- `unsiloed_extract` has optional arguments, so Snowflake won't let you create another function called `unsiloed_extract` with a different number of arguments. Drop the old one first if you have one.
 
 See the [Snowflake integration guide](https://docs.unsiloed.ai/integrations/snowflake) for the full walkthrough, including the Cortex Agent option (running the UDF through Snowflake's Managed MCP server) for interactive, natural-language extraction.

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -2,24 +2,25 @@
 
 Extract structured data from documents in a Snowflake stage using Unsiloed, entirely in SQL. A Python UDF reads each staged file and sends its bytes to Unsiloed's `/v2/extract` endpoint over an [External Access Integration](https://docs.snowflake.com/en/developer-guide/external-network-access/external-network-access-overview), returning typed fields with confidence scores and citations.
 
-## Prerequisites
+## Prerequisites for the Snowflake UDF
 
 - A Snowflake role that can create a network rule, secret, external access integration, and function (`ACCOUNTADMIN` works).
 - An Unsiloed API key. [Sign up at unsiloed.ai](https://www.unsiloed.ai).
 - A stage holding your documents. For an internal stage, create it with `ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')` so `SnowflakeFile` can read it.
 
-## Setup
+## Create the UDF in a Worksheet
 
 1. Open `setup.sql`, set your database and schema, and paste your Unsiloed API key into the secret.
 2. Run it in a Snowflake worksheet. It creates the network rule, secret, external access integration, and the `unsiloed_extract` function.
 
-## Use it
+## Extract Fields from a Staged File
 
-Call the function with a scoped URL for a staged file and a JSON Schema describing the fields you want:
+Call the function with a scoped URL for a staged file, the file's name, and a JSON Schema describing the fields you want:
 
 ```sql
 SELECT unsiloed_extract(
     BUILD_SCOPED_FILE_URL(@MY_DB.MY_SCHEMA.PDF_STAGE, 'invoice.pdf'),
+    'invoice.pdf',
     '{
        "type": "object",
        "properties": {
@@ -30,6 +31,8 @@ SELECT unsiloed_extract(
      }'
 ) AS result;
 ```
+
+Pass the name separately because Unsiloed decides how to decode the file from its extension, and a scoped file URL is encrypted, so the UDF can't read the name back out of it. Images and Office files work the same way.
 
 Each field comes back as an object with a value, a confidence score, and a citation:
 
@@ -43,28 +46,27 @@ Each field comes back as an object with a value, a confidence score, and a citat
 }
 ```
 
-`bbox` is `[x0, y0, x1, y1]` in points, measured against the `page_width` and `page_height` in the same object, so you can scale it to whatever you render the page at.
+The `bbox` array holds `[x0, y0, x1, y1]` in points, measured against the `page_width` and `page_height` in the same object, so you can scale it to whatever size you render the page at.
 
-Because Unsiloed accepts an array-of-objects schema, repeating rows (line items, holdings, table rows) need no columnar rewrite. To process a whole stage in one query, join to `DIRECTORY(@stage)`.
+Unsiloed accepts an array-of-objects schema, so repeating rows (line items, holdings, table rows) need no columnar rewrite.
 
-## File types
+## Extract Every File in a Stage
 
-`/v2/extract` chooses its decoder from the file extension, and a scoped file URL is encrypted, so the UDF can't read the name off the URL. It identifies PDFs, PNG, JPEG and TIFF images, Office files, and HTML from the leading bytes instead. If you have a format it doesn't recognise, pass the name yourself as the third argument:
+Join to `DIRECTORY(@stage)`, which gives you `relative_path` for both the URL and the name:
 
 ```sql
-SELECT unsiloed_extract(
-    BUILD_SCOPED_FILE_URL(@MY_DB.MY_SCHEMA.DOC_STAGE, 'contract.docx'),
-    '{ "type": "object", "properties": { "counterparty": { "type": "string" } } }',
-    'contract.docx'
-) AS result;
+SELECT relative_path,
+       unsiloed_extract(BUILD_SCOPED_FILE_URL(@MY_DB.MY_SCHEMA.PDF_STAGE, relative_path),
+                        relative_path,
+                        '{ "type": "object", "properties": { "total": { "type": "string" } } }') AS result
+FROM DIRECTORY(@MY_DB.MY_SCHEMA.PDF_STAGE);
 ```
 
-Joining to `DIRECTORY(@stage)` gives you `relative_path` for exactly this.
-
-## Notes
+## Limits to Watch For
 
 - The UDF polls for up to five minutes (`MAX_POLLS` × `POLL_SECONDS` in `setup.sql`). Long multi-page documents can need more, so raise `MAX_POLLS` if you see `{"_unsiloed_error": "timeout"}`.
 - The first call after creating the external access integration sometimes times out while the Python environment cold-starts. Run it again.
-- `unsiloed_extract` has optional arguments, so Snowflake won't let you create another function called `unsiloed_extract` with a different number of arguments. Drop the old one first if you have one.
+- The `file_name` argument has to carry an extension. Without one the UDF returns `{"_unsiloed_error": "file_name needs an extension..."}` instead of letting the API guess wrong.
+- The `model` argument is optional, so Snowflake won't let you create another `unsiloed_extract` with a different number of arguments. Drop the old one first if you have one.
 
 See the [Snowflake integration guide](https://docs.unsiloed.ai/integrations/snowflake) for the full walkthrough, including the Cortex Agent option (running the UDF through Snowflake's Managed MCP server) for interactive, natural-language extraction.

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -1,0 +1,48 @@
+# Unsiloed × Snowflake (SQL UDF)
+
+Extract structured data from documents in a Snowflake stage using Unsiloed, entirely in SQL. A Python UDF reads each staged file and sends its bytes to Unsiloed's `/v2/extract` endpoint over an [External Access Integration](https://docs.snowflake.com/en/developer-guide/external-network-access/external-network-access-overview), returning typed fields with confidence scores and citations.
+
+## Prerequisites
+
+- A Snowflake role that can create a network rule, secret, external access integration, and function (`ACCOUNTADMIN` works).
+- An Unsiloed API key — [sign up at unsiloed.ai](https://www.unsiloed.ai).
+- A stage holding your documents. For an internal stage, create it with `ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')` so `SnowflakeFile` can read it.
+
+## Setup
+
+1. Open `setup.sql`, set your database and schema, and paste your Unsiloed API key into the secret.
+2. Run it in a Snowflake worksheet. It creates the network rule, secret, external access integration, and the `unsiloed_extract` function.
+
+## Use it
+
+Call the function with a scoped URL for a staged file and a JSON Schema describing the fields you want:
+
+```sql
+SELECT unsiloed_extract(
+    BUILD_SCOPED_FILE_URL(@MY_DB.MY_SCHEMA.PDF_STAGE, 'invoice.pdf'),
+    '{
+       "type": "object",
+       "properties": {
+         "vendor": { "type": "string" },
+         "invoice_number": { "type": "string" },
+         "total": { "type": "string" }
+       }
+     }'
+) AS result;
+```
+
+Each field comes back as an object with a value, a confidence score, and a citation:
+
+```json
+{
+  "total": {
+    "value": "$4.11",
+    "score": { "grounding_score": 0.998, "extraction_score": 0.992 },
+    "citation": { "page": 1, "bbox": [541, 142, 573, 155] }
+  }
+}
+```
+
+Because Unsiloed accepts an array-of-objects schema, repeating rows (line items, holdings, table rows) need no columnar rewrite. To process a whole stage in one query, join to `DIRECTORY(@stage)`.
+
+See the [Snowflake integration guide](https://docs.unsiloed.ai/integrations/snowflake) for the full walkthrough, including the Cortex Agent option (running the UDF through Snowflake's Managed MCP server) for interactive, natural-language extraction.

--- a/snowflake/setup.sql
+++ b/snowflake/setup.sql
@@ -1,0 +1,83 @@
+-- Unsiloed x Snowflake: extract documents from a stage, entirely in SQL.
+--
+-- Creates a Python UDF that reads a staged file and sends its bytes to Unsiloed's
+-- /v2/extract endpoint over an External Access Integration, returning typed fields
+-- with confidence scores.
+--
+-- Prerequisites:
+--   * A role that can create network rules, secrets, integrations, and functions
+--     (ACCOUNTADMIN works).
+--   * An Unsiloed API key: https://www.unsiloed.ai
+--   * A stage holding your documents. For an internal stage, create it with
+--     ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE') so SnowflakeFile can read it.
+--
+-- Set your database and schema, then run this file in a Snowflake worksheet.
+
+USE DATABASE MY_DB;
+USE SCHEMA MY_SCHEMA;
+
+-- 1. Allow egress to the Unsiloed API host.
+CREATE OR REPLACE NETWORK RULE unsiloed_api_network_rule
+  MODE = EGRESS
+  TYPE = HOST_PORT
+  VALUE_LIST = ('prod.visionapi.unsiloed.ai');
+
+-- 2. Store your Unsiloed API key as a secret (it never appears in UDF source or query text).
+CREATE OR REPLACE SECRET unsiloed_api_key
+  TYPE = GENERIC_STRING
+  SECRET_STRING = 'usk_your_key_here';   -- replace with your key
+
+-- 3. Bind the network rule and secret into an external access integration.
+CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION unsiloed_access_integration
+  ALLOWED_NETWORK_RULES = (unsiloed_api_network_rule)
+  ALLOWED_AUTHENTICATION_SECRETS = (unsiloed_api_key)
+  ENABLED = TRUE;
+
+-- 4. The UDF: read a staged file, POST the bytes to /v2/extract, poll, return the result.
+CREATE OR REPLACE FUNCTION unsiloed_extract(file_url STRING, schema_json STRING, model STRING DEFAULT 'gamma')
+  RETURNS VARIANT
+  LANGUAGE PYTHON
+  RUNTIME_VERSION = '3.12'
+  HANDLER = 'run'
+  EXTERNAL_ACCESS_INTEGRATIONS = (unsiloed_access_integration)
+  PACKAGES = ('requests', 'snowflake-snowpark-python')
+  SECRETS = ('cred' = unsiloed_api_key)
+AS
+$$
+import json, time
+import _snowflake, requests
+from snowflake.snowpark.files import SnowflakeFile
+
+BASE = "https://prod.visionapi.unsiloed.ai"
+
+def run(file_url, schema_json, model):
+    api_key = _snowflake.get_generic_secret_string("cred")
+    headers = {"api-key": api_key}
+
+    # Read the staged file through the caller-scoped URL.
+    with SnowflakeFile.open(file_url, "rb") as f:
+        data = f.read()
+
+    # Submit the extraction job.
+    resp = requests.post(
+        f"{BASE}/v2/extract",
+        headers=headers,
+        files={"pdf_file": ("document.pdf", data, "application/pdf")},
+        data={"schema_data": schema_json, "model": model or "gamma", "enable_citations": "true"},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    job_id = resp.json().get("job_id")
+    if not job_id:
+        return {"_unsiloed_error": "no job_id returned", "response": resp.json()}
+
+    # Poll for up to two minutes.
+    for _ in range(40):
+        time.sleep(3)
+        status = requests.get(f"{BASE}/extract/{job_id}", headers=headers, timeout=30).json()
+        if status.get("status") in ("completed", "review"):
+            return status.get("result", {})
+        if status.get("status") == "failed":
+            return {"_unsiloed_error": "extraction failed", "job_id": job_id, "response": status}
+    return {"_unsiloed_error": "timeout", "job_id": job_id}
+$$;

--- a/snowflake/setup.sql
+++ b/snowflake/setup.sql
@@ -34,14 +34,13 @@ CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION unsiloed_access_integration
   ENABLED = TRUE;
 
 -- 4. The UDF: read a staged file, POST the bytes to /v2/extract, poll, return the result.
---    file_name is optional: /v2/extract picks its decoder from the file extension, and a
---    scoped file URL is encrypted, so the name can't be recovered from it. The UDF sniffs
---    the format from the leading bytes; pass file_name to override (Office files, or any
---    format the sniffer doesn't know).
+--    Pass file_name as well as the URL: /v2/extract picks its decoder from the file
+--    extension, and a scoped file URL is encrypted, so the name can't be recovered from
+--    it. You already have the name -- it's the second argument to BUILD_SCOPED_FILE_URL.
 CREATE OR REPLACE FUNCTION unsiloed_extract(
     file_url STRING,
+    file_name STRING,
     schema_json STRING,
-    file_name STRING DEFAULT '',
     model STRING DEFAULT 'gamma')
   RETURNS VARIANT
   LANGUAGE PYTHON
@@ -52,52 +51,31 @@ CREATE OR REPLACE FUNCTION unsiloed_extract(
   SECRETS = ('cred' = unsiloed_api_key)
 AS
 $$
-import io, json, time, zipfile
+import json, time
 import _snowflake, requests
 from snowflake.snowpark.files import SnowflakeFile
 
 BASE = "https://prod.visionapi.unsiloed.ai"
 MAX_POLLS, POLL_SECONDS = 100, 3   # 5-minute ceiling; raise for long documents
 
-def sniff_name(data):
-    """Name the upload after its real format, since /v2/extract keys off the extension."""
-    if data[:4] == b"%PDF":
-        return "document.pdf"
-    if data[:8] == b"\x89PNG\r\n\x1a\n":
-        return "document.png"
-    if data[:3] == b"\xff\xd8\xff":
-        return "document.jpg"
-    if data[:4] in (b"II*\x00", b"MM\x00*"):
-        return "document.tiff"
-    if data[:2] == b"PK":                      # Office files are zip containers
-        try:
-            with zipfile.ZipFile(io.BytesIO(data)) as z:
-                names = z.namelist()
-        except zipfile.BadZipFile:
-            names = []
-        for prefix, ext in (("word/", "docx"), ("xl/", "xlsx"), ("ppt/", "pptx")):
-            if any(n.startswith(prefix) for n in names):
-                return "document." + ext
-    if data[:15].lstrip()[:1] == b"<":
-        return "document.html"
-    return "document.pdf"
-
-def run(file_url, schema_json, file_name, model):
+def run(file_url, file_name, schema_json, model):
     api_key = _snowflake.get_generic_secret_string("cred")
     headers = {"api-key": api_key}
+
+    # The extension decides how the file is decoded, so insist on having one.
+    if not file_name or "." not in file_name:
+        return {"_unsiloed_error": "file_name needs an extension, e.g. 'invoice.pdf'",
+                "file_name": file_name}
 
     # Read the staged file through the caller-scoped URL.
     with SnowflakeFile.open(file_url, "rb") as f:
         data = f.read()
 
-    # An explicit file_name wins; otherwise name it after the leading bytes.
-    name = file_name if file_name and "." in file_name else sniff_name(data)
-
     # Submit the extraction job.
     resp = requests.post(
         f"{BASE}/v2/extract",
         headers=headers,
-        files={"pdf_file": (name, data)},
+        files={"pdf_file": (file_name, data)},
         data={"schema_data": schema_json, "model": model or "gamma", "enable_citations": "true"},
         timeout=60,
     )

--- a/snowflake/setup.sql
+++ b/snowflake/setup.sql
@@ -25,7 +25,7 @@ CREATE OR REPLACE NETWORK RULE unsiloed_api_network_rule
 -- 2. Store your Unsiloed API key as a secret (it never appears in UDF source or query text).
 CREATE OR REPLACE SECRET unsiloed_api_key
   TYPE = GENERIC_STRING
-  SECRET_STRING = 'usk_your_key_here';   -- replace with your key
+  SECRET_STRING = 'unsiloed_your_key_here';   -- replace with your key
 
 -- 3. Bind the network rule and secret into an external access integration.
 CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION unsiloed_access_integration
@@ -34,7 +34,15 @@ CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION unsiloed_access_integration
   ENABLED = TRUE;
 
 -- 4. The UDF: read a staged file, POST the bytes to /v2/extract, poll, return the result.
-CREATE OR REPLACE FUNCTION unsiloed_extract(file_url STRING, schema_json STRING, model STRING DEFAULT 'gamma')
+--    file_name is optional: /v2/extract picks its decoder from the file extension, and a
+--    scoped file URL is encrypted, so the name can't be recovered from it. The UDF sniffs
+--    the format from the leading bytes; pass file_name to override (Office files, or any
+--    format the sniffer doesn't know).
+CREATE OR REPLACE FUNCTION unsiloed_extract(
+    file_url STRING,
+    schema_json STRING,
+    file_name STRING DEFAULT '',
+    model STRING DEFAULT 'gamma')
   RETURNS VARIANT
   LANGUAGE PYTHON
   RUNTIME_VERSION = '3.12'
@@ -44,13 +52,37 @@ CREATE OR REPLACE FUNCTION unsiloed_extract(file_url STRING, schema_json STRING,
   SECRETS = ('cred' = unsiloed_api_key)
 AS
 $$
-import json, time
+import io, json, time, zipfile
 import _snowflake, requests
 from snowflake.snowpark.files import SnowflakeFile
 
 BASE = "https://prod.visionapi.unsiloed.ai"
+MAX_POLLS, POLL_SECONDS = 100, 3   # 5-minute ceiling; raise for long documents
 
-def run(file_url, schema_json, model):
+def sniff_name(data):
+    """Name the upload after its real format, since /v2/extract keys off the extension."""
+    if data[:4] == b"%PDF":
+        return "document.pdf"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "document.png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "document.jpg"
+    if data[:4] in (b"II*\x00", b"MM\x00*"):
+        return "document.tiff"
+    if data[:2] == b"PK":                      # Office files are zip containers
+        try:
+            with zipfile.ZipFile(io.BytesIO(data)) as z:
+                names = z.namelist()
+        except zipfile.BadZipFile:
+            names = []
+        for prefix, ext in (("word/", "docx"), ("xl/", "xlsx"), ("ppt/", "pptx")):
+            if any(n.startswith(prefix) for n in names):
+                return "document." + ext
+    if data[:15].lstrip()[:1] == b"<":
+        return "document.html"
+    return "document.pdf"
+
+def run(file_url, schema_json, file_name, model):
     api_key = _snowflake.get_generic_secret_string("cred")
     headers = {"api-key": api_key}
 
@@ -58,11 +90,14 @@ def run(file_url, schema_json, model):
     with SnowflakeFile.open(file_url, "rb") as f:
         data = f.read()
 
+    # An explicit file_name wins; otherwise name it after the leading bytes.
+    name = file_name if file_name and "." in file_name else sniff_name(data)
+
     # Submit the extraction job.
     resp = requests.post(
         f"{BASE}/v2/extract",
         headers=headers,
-        files={"pdf_file": ("document.pdf", data, "application/pdf")},
+        files={"pdf_file": (name, data)},
         data={"schema_data": schema_json, "model": model or "gamma", "enable_citations": "true"},
         timeout=60,
     )
@@ -71,10 +106,15 @@ def run(file_url, schema_json, model):
     if not job_id:
         return {"_unsiloed_error": "no job_id returned", "response": resp.json()}
 
-    # Poll for up to two minutes.
-    for _ in range(40):
-        time.sleep(3)
-        status = requests.get(f"{BASE}/extract/{job_id}", headers=headers, timeout=30).json()
+    # Poll until the job reaches a terminal state, riding out transient network errors.
+    for _ in range(MAX_POLLS):
+        time.sleep(POLL_SECONDS)
+        try:
+            status = requests.get(f"{BASE}/extract/{job_id}", headers=headers, timeout=30).json()
+        except (requests.RequestException, ValueError):
+            continue
+        # "review" is terminal and carries a result: the job finished but was flagged
+        # for human review, so treat it like "completed".
         if status.get("status") in ("completed", "review"):
             return status.get("result", {})
         if status.get("status") == "failed":


### PR DESCRIPTION
## Description

Extract structured data from documents in a Snowflake stage using Unsiloed, entirely in SQL. A Python UDF over an External Access Integration reads each staged file and sends it to Unsiloed's `/v2/extract`, returning typed fields with confidence scores and citations. `snowflake/setup.sql` creates the network rule, secret, integration, and UDF; `snowflake/README.md` covers setup and usage.

## Checklist

- [x] Example runs successfully with valid API keys
- [x] No API keys, secrets, or internal details committed
- [ ] Notebook outputs are cleared — N/A (SQL example, no notebook)
- [x] README.md included with setup instructions
- [ ] Dependencies added to `pyproject.toml` or a local `requirements.txt` — N/A (the UDF declares its Python packages inline via Snowflake `PACKAGES=(...)`)
