### PR TITLE
n8n node: publish 1.0.1 to npm and fix API key leak

### DIFF
--- a/n8n-nodes-unsiloed/README.md
+++ b/n8n-nodes-unsiloed/README.md
@@ -22,13 +22,30 @@ The node has two operations:
 - **Parse:** OCR the document and return layout-aware Markdown (headings, tables, paragraphs). No schema required.
 - **Extract:** pull named fields into JSON using a schema you define (invoice number, totals, dates, line items). Each value comes back with a confidence score and a citation (page and bounding box).
 
-## Installing on Self-Hosted n8n
+## Installing
 
-The node ships via GitHub and installs into n8n's custom extensions folder (`~/.n8n/custom`). There's no build step, because the compiled `dist/` is committed. Once loaded, the node type is `CUSTOM.unsiloed`.
+The node is published on npm as [`n8n-nodes-unsiloed`](https://www.npmjs.com/package/n8n-nodes-unsiloed), so you can install it from n8n's own UI, with no terminal and no restart:
 
-n8n Cloud can't load nodes from disk; it only supports npm-published community nodes, so this install is for self-hosted n8n (Docker or a local install).
+1. Open **Settings → Community Nodes → Install**.
+2. Enter `n8n-nodes-unsiloed` and confirm.
+3. Search for **Unsiloed** in the node panel.
 
-If you run n8n in Docker, clone the cookbook, copy the compiled node into the container, and restart it:
+Once installed, the node type is `n8n-nodes-unsiloed.unsiloed`.
+
+This is for self-hosted n8n. n8n Cloud only allows community nodes that n8n has itself verified, and this node isn't verified yet, so Cloud users need a self-hosted instance for now.
+
+If you'd rather install from the command line, add it to your n8n user folder and restart n8n:
+
+```bash
+mkdir -p ~/.n8n/nodes && cd ~/.n8n/nodes
+npm install n8n-nodes-unsiloed
+```
+
+### Installing From Source Instead
+
+You only need this if you're modifying the node. n8n loads anything in `~/.n8n/custom` on startup, and the compiled `dist/` is committed, so no build step is required. Note that a node loaded this way registers as `CUSTOM.unsiloed`, **not** `n8n-nodes-unsiloed.unsiloed` — so workflows exported from one install won't import into the other without editing the node's `type`.
+
+For Docker:
 
 ```bash
 git clone https://github.com/Unsiloed-AI/cookbook
@@ -42,15 +59,14 @@ Or run the bundled installer from the node's folder:
 cd cookbook/n8n-nodes-unsiloed && ./install.sh <your-n8n-container>
 ```
 
-If you run n8n locally (npm or global install), copy the compiled node into your user folder and restart n8n:
+For a local n8n install:
 
 ```bash
 git clone https://github.com/Unsiloed-AI/cookbook
 mkdir -p ~/.n8n/custom
 cp -r cookbook/n8n-nodes-unsiloed/dist/* ~/.n8n/custom/
+# then restart n8n
 ```
-
-After the restart, search for **Unsiloed** in the node panel.
 
 ## Setting Up the Credential
 
@@ -58,6 +74,8 @@ Create an **Unsiloed API** credential on the node:
 
 - **API Key:** your Unsiloed key (get one at unsiloed.ai)
 - **Base URL:** `https://prod.visionapi.unsiloed.ai` (the default)
+
+Use the credential's **Test** button to confirm the key works before you run a workflow.
 
 ## Using the Node
 
@@ -96,11 +114,23 @@ Extract returns structured JSON, so you tell it which fields to pull with a JSON
 }
 ```
 
-Each property becomes a key in the output, with its `value`, a per-field `grounding_score` and `extraction_score`, and a `citation` (page and bounding box) you can act on. To run Extract on a different document, change the property names and descriptions to the fields you want. The schema above is generic enough to work on most invoices as-is; a receipt, a contract, or an ID needs its own field list.
+Each property becomes a key in the output, holding a `value`, a nested `score` (with `grounding_score` and `extraction_score`), and a `citation` you can act on:
+
+```json
+{
+  "total_due": {
+    "value": "$11,557.22",
+    "score": { "grounding_score": 0.998, "extraction_score": 0.998 },
+    "citation": { "page": 1, "bbox": [470, 577, 533, 592], "page_width": 595.28, "page_height": 841.89 }
+  }
+}
+```
+
+So in later steps the value is `{{ $json.total_due.value }}` and its confidence is `{{ $json.total_due.score.grounding_score }}` — the scores are nested under `score`, not on the field itself. To run Extract on a different document, change the property names and descriptions to the fields you want. The schema above is generic enough to work on most invoices as-is; a receipt, a contract, or an ID needs its own field list.
 
 Extraction runs on Unsiloed's `gamma` model (the recommended, most thorough tier), with citations enabled so every field comes back grounded.
 
-Once you have the output, wire it into a spreadsheet, a database, a notification, or a language-model step. The [`examples/`](./examples) folder has a ready-to-import Parse workflow with a sample document.
+Once you have the output, wire it into a spreadsheet, a database, a notification, or a language-model step. The [`examples/` folder in the repo](https://github.com/Unsiloed-AI/cookbook/tree/main/n8n-nodes-unsiloed/examples) has a ready-to-import Parse workflow with a sample document.
 
 ## Building From Source
 

--- a/n8n-nodes-unsiloed/credentials/UnsiloedApi.credentials.ts
+++ b/n8n-nodes-unsiloed/credentials/UnsiloedApi.credentials.ts
@@ -30,7 +30,10 @@ export class UnsiloedApi implements ICredentialType {
 		},
 	];
 
-	// Sends the api-key header on n8n's built-in "Test" and on generic HTTP calls.
+	// Sends the api-key header on generic HTTP calls. The "Test" button is wired up
+	// separately, by the node's `unsiloedApiTest` method (see Unsiloed.node.ts) —
+	// Unsiloed has no endpoint that returns 2xx for an authenticated GET, which is
+	// what a declarative `test` block would need.
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {

--- a/n8n-nodes-unsiloed/dist/credentials/UnsiloedApi.credentials.js
+++ b/n8n-nodes-unsiloed/dist/credentials/UnsiloedApi.credentials.js
@@ -24,7 +24,10 @@ class UnsiloedApi {
                 description: 'Unsiloed API base URL. Change only for a private / self-hosted deployment.',
             },
         ];
-        // Sends the api-key header on n8n's built-in "Test" and on generic HTTP calls.
+        // Sends the api-key header on generic HTTP calls. The "Test" button is wired up
+        // separately, by the node's `unsiloedApiTest` method (see Unsiloed.node.ts) —
+        // Unsiloed has no endpoint that returns 2xx for an authenticated GET, which is
+        // what a declarative `test` block would need.
         this.authenticate = {
             type: 'generic',
             properties: {

--- a/n8n-nodes-unsiloed/dist/nodes/Unsiloed/Unsiloed.node.js
+++ b/n8n-nodes-unsiloed/dist/nodes/Unsiloed/Unsiloed.node.js
@@ -24,6 +24,7 @@ class Unsiloed {
                 {
                     name: 'unsiloedApi',
                     required: true,
+                    testedBy: 'unsiloedApiTest',
                 },
             ],
             properties: [
@@ -96,6 +97,51 @@ class Unsiloed {
                 },
             ],
         };
+        this.methods = {
+            credentialTest: {
+                // Backs the credential's "Test" button. Unsiloed exposes no endpoint that
+                // returns 2xx for an authenticated read, so we POST to /parse with no file
+                // and read the rejection: 400/422 means the key authenticated and the route
+                // exists, 401/403 means the key is bad, and anything else (404 from a path
+                // typo, 405 from an unrelated host) means the Base URL is wrong.
+                async unsiloedApiTest(credential) {
+                    const data = (credential.data ?? {});
+                    const apiKey = data.apiKey || '';
+                    const baseUrl = (data.baseUrl || 'https://prod.visionapi.unsiloed.ai').replace(/\/+$/, '');
+                    if (!apiKey) {
+                        return { status: 'Error', message: 'No API key set.' };
+                    }
+                    try {
+                        const response = await this.helpers.request({
+                            method: 'POST',
+                            uri: `${baseUrl}/parse`,
+                            headers: { 'api-key': apiKey },
+                            json: true,
+                            simple: false,
+                            resolveWithFullResponse: true,
+                        });
+                        const status = response.statusCode;
+                        if (status === 401 || status === 403) {
+                            return { status: 'Error', message: 'Unsiloed rejected this API key.' };
+                        }
+                        // The key authenticated and /parse rejected the empty request body.
+                        if (status === 400 || status === 422) {
+                            return { status: 'OK', message: 'Connection successful!' };
+                        }
+                        return {
+                            status: 'Error',
+                            message: `Unexpected response from Unsiloed (HTTP ${status}). Check the Base URL.`,
+                        };
+                    }
+                    catch (error) {
+                        return {
+                            status: 'Error',
+                            message: `Could not reach Unsiloed at ${baseUrl}: ${error.message}`,
+                        };
+                    }
+                },
+            },
+        };
     }
     async execute() {
         const items = this.getInputData();
@@ -103,14 +149,26 @@ class Unsiloed {
         const credentials = await this.getCredentials('unsiloedApi');
         const apiKey = credentials.apiKey;
         const baseUrl = (credentials.baseUrl || 'https://prod.visionapi.unsiloed.ai').replace(/\/+$/, '');
+        // Every Unsiloed call goes through here. A raw failure from helpers.request is an
+        // AxiosError carrying the request options — including the api-key header — and n8n
+        // persists thrown errors into the execution record, so it must never escape as-is.
+        // NodeApiError keeps only message/description/httpCode/level/context.
+        const request = async (options) => {
+            try {
+                return (await this.helpers.request(options));
+            }
+            catch (error) {
+                throw new n8n_workflow_1.NodeApiError(this.getNode(), error);
+            }
+        };
         const poll = async (path) => {
             for (let attempt = 0; attempt < 90; attempt++) {
-                const job = (await this.helpers.request({
+                const job = await request({
                     method: 'GET',
                     uri: `${baseUrl}${path}`,
                     headers: { 'api-key': apiKey },
                     json: true,
-                }));
+                });
                 const status = job.status;
                 if (DONE.includes(status))
                     return job;
@@ -144,13 +202,13 @@ class Unsiloed {
                     };
                     if (forceOcr)
                         formData.ocr_strategy = 'force_ocr';
-                    const submit = (await this.helpers.request({
+                    const submit = await request({
                         method: 'POST',
                         uri: `${baseUrl}/parse`,
                         headers: { 'api-key': apiKey },
                         formData,
                         json: true,
-                    }));
+                    });
                     const result = await poll(`/parse/${submit.job_id}`);
                     if (output === 'json') {
                         returnData.push({ json: result, pairedItem: { item: i } });
@@ -179,7 +237,7 @@ class Unsiloed {
                     // operation === 'extract'
                     const schemaRaw = this.getNodeParameter('schema', i);
                     const schema = typeof schemaRaw === 'string' ? schemaRaw : JSON.stringify(schemaRaw);
-                    const submit = (await this.helpers.request({
+                    const submit = await request({
                         method: 'POST',
                         uri: `${baseUrl}/v2/extract`,
                         headers: { 'api-key': apiKey },
@@ -192,7 +250,7 @@ class Unsiloed {
                             enable_citations: 'true',
                         },
                         json: true,
-                    }));
+                    });
                     const job = await poll(`/extract/${submit.job_id}`);
                     const result = job.result ?? job;
                     returnData.push({ json: result, pairedItem: { item: i } });

--- a/n8n-nodes-unsiloed/dist/nodes/Unsiloed/Unsiloed.node.json
+++ b/n8n-nodes-unsiloed/dist/nodes/Unsiloed/Unsiloed.node.json
@@ -1,5 +1,5 @@
 {
-	"node": "n8n-nodes-base.unsiloed",
+	"node": "n8n-nodes-unsiloed.unsiloed",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Data & Storage", "Utility"],

--- a/n8n-nodes-unsiloed/examples/README.md
+++ b/n8n-nodes-unsiloed/examples/README.md
@@ -11,8 +11,11 @@ First, install the node (see the main README) and create your **Unsiloed API** c
 Next, put the sample invoice where n8n can read it. n8n restricts file reads to `~/.n8n-files` by default, so copy it there. If you run n8n in Docker:
 
 ```bash
+docker exec <your-n8n-container> mkdir -p /home/node/.n8n-files
 docker cp sample-invoice.pdf <your-n8n-container>:/home/node/.n8n-files/invoice.pdf
 ```
+
+(The `mkdir` matters: `.n8n-files` doesn't exist until n8n creates it, and `docker cp` fails if the directory is missing.)
 
 If you run n8n locally:
 
@@ -21,5 +24,10 @@ mkdir -p ~/.n8n-files && cp sample-invoice.pdf ~/.n8n-files/invoice.pdf
 ```
 
 Then import `invoice-to-markdown.json` in n8n (Workflows → ⋯ → Import from File), open the **Unsiloed** node, select your credential, and run the workflow. You should get the invoice back as clean Markdown.
+
+Two things to check if the import doesn't run:
+
+- **File path.** The workflow ships with the Docker path (`/home/node/.n8n-files/invoice.pdf`). On a local n8n, open the "Read invoice.pdf" node and change it to your own `~/.n8n-files/invoice.pdf` (expanded, e.g. `/Users/you/.n8n-files/invoice.pdf`).
+- **Node type.** The workflow references `n8n-nodes-unsiloed.unsiloed`, which is how the node registers when installed from npm. If you installed from source into `~/.n8n/custom` instead, the node registers as `CUSTOM.unsiloed` and n8n will show "Unrecognized node type" — either install from npm or edit the node's `type` in the JSON.
 
 To try it on your own document, point the "Read invoice.pdf" node at a different file. A scan or a phone photo shows the difference best.

--- a/n8n-nodes-unsiloed/examples/invoice-to-markdown.json
+++ b/n8n-nodes-unsiloed/examples/invoice-to-markdown.json
@@ -37,7 +37,7 @@
       },
       "id": "22222222-2222-4222-8222-222222222223",
       "name": "Unsiloed",
-      "type": "CUSTOM.unsiloed",
+      "type": "n8n-nodes-unsiloed.unsiloed",
       "typeVersion": 1,
       "position": [
         520,

--- a/n8n-nodes-unsiloed/nodes/Unsiloed/Unsiloed.node.json
+++ b/n8n-nodes-unsiloed/nodes/Unsiloed/Unsiloed.node.json
@@ -1,5 +1,5 @@
 {
-	"node": "n8n-nodes-base.unsiloed",
+	"node": "n8n-nodes-unsiloed.unsiloed",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Data & Storage", "Utility"],

--- a/n8n-nodes-unsiloed/nodes/Unsiloed/Unsiloed.node.ts
+++ b/n8n-nodes-unsiloed/nodes/Unsiloed/Unsiloed.node.ts
@@ -1,6 +1,9 @@
 import {
 	IExecuteFunctions,
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
 	IDataObject,
+	INodeCredentialTestResult,
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
@@ -33,6 +36,7 @@ export class Unsiloed implements INodeType {
 			{
 				name: 'unsiloedApi',
 				required: true,
+				testedBy: 'unsiloedApiTest',
 			},
 		],
 		properties: [
@@ -109,6 +113,61 @@ export class Unsiloed implements INodeType {
 		],
 	};
 
+	methods = {
+		credentialTest: {
+			// Backs the credential's "Test" button. Unsiloed exposes no endpoint that
+			// returns 2xx for an authenticated read, so we POST to /parse with no file
+			// and read the rejection: 400/422 means the key authenticated and the route
+			// exists, 401/403 means the key is bad, and anything else (404 from a path
+			// typo, 405 from an unrelated host) means the Base URL is wrong.
+			async unsiloedApiTest(
+				this: ICredentialTestFunctions,
+				credential: ICredentialsDecrypted,
+			): Promise<INodeCredentialTestResult> {
+				const data = (credential.data ?? {}) as IDataObject;
+				const apiKey = (data.apiKey as string) || '';
+				const baseUrl = ((data.baseUrl as string) || 'https://prod.visionapi.unsiloed.ai').replace(
+					/\/+$/,
+					'',
+				);
+
+				if (!apiKey) {
+					return { status: 'Error', message: 'No API key set.' };
+				}
+
+				try {
+					const response = await this.helpers.request({
+						method: 'POST',
+						uri: `${baseUrl}/parse`,
+						headers: { 'api-key': apiKey },
+						json: true,
+						simple: false,
+						resolveWithFullResponse: true,
+					});
+
+					const status = response.statusCode as number;
+
+					if (status === 401 || status === 403) {
+						return { status: 'Error', message: 'Unsiloed rejected this API key.' };
+					}
+					// The key authenticated and /parse rejected the empty request body.
+					if (status === 400 || status === 422) {
+						return { status: 'OK', message: 'Connection successful!' };
+					}
+					return {
+						status: 'Error',
+						message: `Unexpected response from Unsiloed (HTTP ${status}). Check the Base URL.`,
+					};
+				} catch (error) {
+					return {
+						status: 'Error',
+						message: `Could not reach Unsiloed at ${baseUrl}: ${(error as Error).message}`,
+					};
+				}
+			},
+		},
+	};
+
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
@@ -117,14 +176,26 @@ export class Unsiloed implements INodeType {
 		const apiKey = credentials.apiKey as string;
 		const baseUrl = ((credentials.baseUrl as string) || 'https://prod.visionapi.unsiloed.ai').replace(/\/+$/, '');
 
+		// Every Unsiloed call goes through here. A raw failure from helpers.request is an
+		// AxiosError carrying the request options — including the api-key header — and n8n
+		// persists thrown errors into the execution record, so it must never escape as-is.
+		// NodeApiError keeps only message/description/httpCode/level/context.
+		const request = async (options: IDataObject): Promise<IDataObject> => {
+			try {
+				return (await this.helpers.request(options)) as IDataObject;
+			} catch (error) {
+				throw new NodeApiError(this.getNode(), error as JsonObject);
+			}
+		};
+
 		const poll = async (path: string): Promise<IDataObject> => {
 			for (let attempt = 0; attempt < 90; attempt++) {
-				const job = (await this.helpers.request({
+				const job = await request({
 					method: 'GET',
 					uri: `${baseUrl}${path}`,
 					headers: { 'api-key': apiKey },
 					json: true,
-				})) as IDataObject;
+				});
 				const status = job.status as string;
 				if (DONE.includes(status)) return job;
 				if (FAILED.includes(status)) {
@@ -161,13 +232,13 @@ export class Unsiloed implements INodeType {
 					};
 					if (forceOcr) formData.ocr_strategy = 'force_ocr';
 
-					const submit = (await this.helpers.request({
+					const submit = await request({
 						method: 'POST',
 						uri: `${baseUrl}/parse`,
 						headers: { 'api-key': apiKey },
 						formData,
 						json: true,
-					})) as IDataObject;
+					});
 
 					const result = await poll(`/parse/${submit.job_id}`);
 
@@ -196,7 +267,7 @@ export class Unsiloed implements INodeType {
 					const schemaRaw = this.getNodeParameter('schema', i) as string | IDataObject;
 					const schema = typeof schemaRaw === 'string' ? schemaRaw : JSON.stringify(schemaRaw);
 
-					const submit = (await this.helpers.request({
+					const submit = await request({
 						method: 'POST',
 						uri: `${baseUrl}/v2/extract`,
 						headers: { 'api-key': apiKey },
@@ -209,7 +280,7 @@ export class Unsiloed implements INodeType {
 							enable_citations: 'true',
 						},
 						json: true,
-					})) as IDataObject;
+					});
 
 					const job = await poll(`/extract/${submit.job_id}`);
 					const result = (job.result as IDataObject) ?? job;

--- a/n8n-nodes-unsiloed/package.json
+++ b/n8n-nodes-unsiloed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-unsiloed",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Unsiloed AI — parse and OCR documents (PDF, scans, images) into clean Markdown inside n8n",
   "keywords": [
     "n8n-community-node-package",
@@ -50,5 +50,10 @@
   },
   "peerDependencies": {
     "n8n-workflow": "*"
+  },
+  "peerDependenciesMeta": {
+    "n8n-workflow": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
- The n8n node is now published on npm, so it can be installed from Settings, Community Nodes, Install, with no terminal needed.
- Fixed a problem where a failed run could save the Unsiloed API key into n8n's execution history, where other users could read it.
- The Unsiloed credential now has a working Test button that confirms whether the API key and Base URL are correct.
- The example workflow now imports and runs correctly for anyone who installs the node from npm. Previously it failed with an unrecognized node error.
- The README now describes the npm install, and correctly explains that n8n Cloud only allows nodes that n8n has verified, which this node is not yet.
- Corrected the documentation for extracted field output, which described the confidence scores in the wrong place.
- Fixed a copy command in the examples README that failed on a new container.
- Installing the node by hand now downloads one package instead of 91.
- Checked on a clean n8n install by installing the published node and running the example document through both operations.
