### PR TITLE
Publish the n8n node from GitHub Actions with provenance

### DIFF
--- a/.github/workflows/publish-n8n-nodes-unsiloed.yml
+++ b/.github/workflows/publish-n8n-nodes-unsiloed.yml
@@ -1,0 +1,76 @@
+name: Publish n8n-nodes-unsiloed
+
+# n8n requires verified community nodes to be published from a GitHub action with an
+# npm provenance statement — it won't verify a node published from a local machine.
+# Auth is npm trusted publishing (OIDC), so there is no NPM_TOKEN secret to manage:
+# the package must list this repo and this workflow filename as its trusted publisher
+# at npmjs.com -> package -> Settings -> Trusted Publisher.
+#
+# Provenance is generated automatically for a public package published this way, so
+# no --provenance flag is needed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run every step but skip the actual publish'
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'n8n-nodes-unsiloed-v*'
+
+permissions:
+  contents: read
+  id-token: write # required for OIDC trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: n8n-nodes-unsiloed
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Node 22 ships npm 10; trusted publishing needs npm >= 11.5.1.
+      - name: Use an npm that supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check this version isn't already on npm
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Publishing $NAME@$VERSION"
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::$NAME@$VERSION is already published. Bump the version in n8n-nodes-unsiloed/package.json."
+            exit 1
+          fi
+
+      - name: Publish to npm
+        if: ${{ inputs.dry_run != true }}
+        run: npm publish --access public
+
+      - name: Publish (dry run)
+        if: ${{ inputs.dry_run == true }}
+        run: npm publish --access public --dry-run
+
+      - name: Verify provenance
+        if: ${{ inputs.dry_run != true }}
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          npx --yes @n8n/scan-community-package "$NAME"

--- a/n8n-nodes-unsiloed/package.json
+++ b/n8n-nodes-unsiloed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-unsiloed",
-  "version": "1.0.1",
-  "description": "Unsiloed AI — parse and OCR documents (PDF, scans, images) into clean Markdown inside n8n",
+  "version": "1.0.2",
+  "description": "Unsiloed AI \u2014 parse and OCR documents (PDF, scans, images) into clean Markdown inside n8n",
   "keywords": [
     "n8n-community-node-package",
     "unsiloed",


### PR DESCRIPTION
- Adds a GitHub Actions workflow that publishes the n8n node to npm, instead of publishing from someone's laptop.
- This is required for n8n verification. n8n will not verify a node that was published locally, and the version currently on npm fails their check for this reason.
- Verification is what allows the node to be installed on n8n Cloud and to appear in n8n's in-app search. Without it the node is self-hosted only.
- Publishing uses npm trusted publishing, so there is no npm token stored in this repo and nothing to rotate.
- Before the first run, the npm package needs this repository and workflow filename added as its trusted publisher in its npm settings.
- To release after this is merged: bump the version in n8n-nodes-unsiloed/package.json, then run the workflow from the Actions tab. It refuses to run if that version was already published.
- The workflow has a dry run option that does everything except the actual publish.
- Bumps the node version to 1.0.2, because 1.0.1 is already on npm and this cannot be applied to a version that already exists.
